### PR TITLE
Fix formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor/


### PR DESCRIPTION
Closes #11

The fix is not perfect as this won't work if another kind of PHP object is passed in the context, how this should handle the most common case.

The idea is like for the dates, we format the exceptions by serializing them. However if the serialization fails, e.g. because an unserializable class is found in the stack trace like a `Closure`, we transform the exception into a normalized array based on the `Throwable` API.

A few other things have been included:

- Added a `.gitignore` project: while `vendor` is debatable `composer.lock` is less, in any case I think there is little harm in including this.
- Replaced the usage of deprecated parameters in `Yaml::dump()` in favour of their new equivalent `Yaml::DUMP_OBJECT`

Note that I only tested locally on my project as there is not proper test on the repo.
