### PR TITLE
Remove BC break (return value type hinting)

### DIFF
--- a/src/EasyLogFormatter.php
+++ b/src/EasyLogFormatter.php
@@ -387,7 +387,7 @@ class EasyLogFormatter implements FormatterInterface
      *
      * @return array
      */
-    private function formatThrowableObjects(array $array): array
+    private function formatThrowableObjects(array $array)
     {
         array_walk_recursive($array, function (&$value) {
             if ($value instanceof \Throwable) {
@@ -402,7 +402,7 @@ class EasyLogFormatter implements FormatterInterface
         return $array;
     }
 
-    private function formatThrowable(Throwable $throwable): array
+    private function formatThrowable(Throwable $throwable)
     {
         return [
             'class' => get_class($throwable),


### PR DESCRIPTION
Return value type hinting is a feature introduced in PHP 7 but is used in release 1.0.5.
http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
This library supports PHP >= 5.3 as stated in composer.json.

Maybe think about some simple travis test instances for some PHP versions?