### PR TITLE
Update EasyLogFormatter.php

### DIFF
--- a/src/EasyLogFormatter.php
+++ b/src/EasyLogFormatter.php
@@ -402,7 +402,7 @@ class EasyLogFormatter implements FormatterInterface
         return $array;
     }
 
-    private function formatThrowable(Throwable $throwable): array
+    private function formatThrowable(\Throwable $throwable): array
     {
         return [
             'class' => get_class($throwable),


### PR DESCRIPTION
Added root namespace for \Throwable. Without that i got:

PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to EasyCorp\EasyLog\EasyLogFormatter::formatThrowable() must be an instance of EasyCorp\EasyLog\Throwable, instance of Symfony\Component\Security\Core\Exception\AccessDeniedException given