### PR TITLE
Bump the Yaml component dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php"             : ">=5.3.0",
         "monolog/monolog" : "~1.6",
-        "symfony/yaml"    : "~2.3|~3.0|~4.0"
+        "symfony/yaml"    : "~3.1|~4.0"
     },
     "autoload": {
         "psr-4": { "EasyCorp\\EasyLog\\": "src" }


### PR DESCRIPTION
The project depends on `Yaml::DUMP_OBJECT` which has been introduced in [this commit](https://github.com/symfony/symfony/commit/286103b2254213eada68517095a6d794b4749d64) available from `symfony/yaml 3.1.0+`

Closes #19